### PR TITLE
bugfix：AbstractWxApi2.call()方法中，sendUrl在URL不以"http"开头时会被赋值为null

### DIFF
--- a/src/main/java/org/nutz/weixin/impl/AbstractWxApi2.java
+++ b/src/main/java/org/nutz/weixin/impl/AbstractWxApi2.java
@@ -272,9 +272,7 @@ public abstract class AbstractWxApi2 implements WxApi2 {
         WxResp wxResp = null;
         while (retry >= 0) {
             try {
-                String sendUrl = null;
-                if (!URL.startsWith("http"))
-                    sendUrl = base + URL;
+                String sendUrl = URL.startsWith("http") ? URL : base + URL;
                 if (URL.contains("?")) {
                     sendUrl += "&access_token=" + token;
                 } else {


### PR DESCRIPTION
bugfix：AbstractWxApi2.call()方法中，sendUrl在URL不以"http"开头时会被赋值为null
导致请求地址变成"null?access_token=..."
修改为当URL不以"http"开头时sendUrl为URL

有些微信API地址中没有"/cgi-bin"，例如微信卡券接口
这时调用call()时的URL需要从头写全，以"http"开头