### PR TITLE
增加功能：微信卡券，查询Code接口；微信卡券，核销卡券接口

### DIFF
--- a/src/main/java/org/nutz/weixin/impl/AbstractWxApi2.java
+++ b/src/main/java/org/nutz/weixin/impl/AbstractWxApi2.java
@@ -258,7 +258,6 @@ public abstract class AbstractWxApi2 implements WxApi2 {
         return call(uri, METHOD.POST, Json.toJson(body));
     }
 
-
     protected WxResp call(String URL, METHOD method, String body) {
         String token = getAccessToken();
         if (log.isInfoEnabled()) {

--- a/src/main/java/org/nutz/weixin/impl/WxApi2Impl.java
+++ b/src/main/java/org/nutz/weixin/impl/WxApi2Impl.java
@@ -296,7 +296,7 @@ public class WxApi2Impl extends AbstractWxApi2 {
     // 微信卡券
 
     /**
-     * 创建卡券
+     * 微信卡券：创建卡券
      *
      * @author JinYi
      * @param card
@@ -309,7 +309,7 @@ public class WxApi2Impl extends AbstractWxApi2 {
     }
 
     /**
-     * 投放卡券，创建二维码
+     * 微信卡券：投放卡券，创建二维码
      *
      * @author JinYi
      * @param body
@@ -317,8 +317,56 @@ public class WxApi2Impl extends AbstractWxApi2 {
      */
     @Override
     public WxResp card_qrcode_create(NutMap body) {
-        // 由于创建卡券API中没有“/cgi-bin”，所以uri不能只写“/card/qrcode/create”
+        // 由于投放卡券创建二维码API中没有“/cgi-bin”，所以uri不能只写“/card/qrcode/create”
         return postJson("https://api.weixin.qq.com/card/qrcode/create", body);
+    }
+
+    /**
+     * 微信卡券：查询Code
+     *
+     * @author JinYi
+     * @param code 单张卡券的唯一标准，必填
+     * @param cardId 卡券ID代表一类卡券，null表示不填此参数。自定义code卡券必填
+     * @param checkConsume 是否校验code核销状态，填入true和false时的code异常状态返回数据不同，null表示不填此参数
+     * @return
+     */
+    @Override
+    public WxResp card_code_get(String code, String cardId, Boolean checkConsume) {
+    	NutMap body = NutMap.NEW().addv("code", code);
+    	if (cardId != null) {
+    		body.addv("card_id", cardId);
+    	}
+    	if (checkConsume != null) {
+    		body.addv("check_consume", checkConsume);
+    	}
+
+    	// 由于查询Code API中没有“/cgi-bin”，所以uri不能只写“/card/code/get”
+    	return postJson("https://api.weixin.qq.com/card/code/get", body);
+    }
+
+    /**
+     * 微信卡券：查询Code
+     *
+     * @author JinYi
+     * @param code 单张卡券的唯一标准，必填
+     * @param cardId 卡券ID代表一类卡券，null表示不填此参数。自定义code卡券必填
+     * @return
+     */
+    @Override
+    public WxResp card_code_get(String code, String cardId) {
+    	return card_code_get(code, cardId, null);
+    }
+
+    /**
+     * 微信卡券：查询Code
+     *
+     * @author JinYi
+     * @param code 单张卡券的唯一标准，必填
+     * @return
+     */
+    @Override
+    public WxResp card_code_get(String code) {
+    	return card_code_get(code, null, null);
     }
 
     // 自定义菜单

--- a/src/main/java/org/nutz/weixin/impl/WxApi2Impl.java
+++ b/src/main/java/org/nutz/weixin/impl/WxApi2Impl.java
@@ -370,7 +370,9 @@ public class WxApi2Impl extends AbstractWxApi2 {
     }
 
     /**
-     * 微信卡券：核销卡券
+     * 微信卡券：核销卡券<br/>
+     * 建议在调用核销卡券接口之前调用查询Code接口<br/>
+     * 以便在核销之前对非法状态的Code（如转赠中、已删除、已核销等）做出处理
      *
      * @author JinYi
      * @param code 需核销的Code码，必填
@@ -389,7 +391,9 @@ public class WxApi2Impl extends AbstractWxApi2 {
     }
 
     /**
-     * 微信卡券：核销卡券
+     * 微信卡券：核销卡券<br/>
+     * 建议在调用核销卡券接口之前调用查询Code接口<br/>
+     * 以便在核销之前对非法状态的Code（如转赠中、已删除、已核销等）做出处理
      *
      * @author JinYi
      * @param code 需核销的Code码，必填

--- a/src/main/java/org/nutz/weixin/impl/WxApi2Impl.java
+++ b/src/main/java/org/nutz/weixin/impl/WxApi2Impl.java
@@ -325,7 +325,7 @@ public class WxApi2Impl extends AbstractWxApi2 {
      * 微信卡券：查询Code
      *
      * @author JinYi
-     * @param code 单张卡券的唯一标准，必填
+     * @param code 卡券Code码，一张卡券的唯一标识，必填
      * @param cardId 卡券ID代表一类卡券，null表示不填此参数。自定义code卡券必填
      * @param checkConsume 是否校验code核销状态，填入true和false时的code异常状态返回数据不同，null表示不填此参数
      * @return
@@ -348,7 +348,7 @@ public class WxApi2Impl extends AbstractWxApi2 {
      * 微信卡券：查询Code
      *
      * @author JinYi
-     * @param code 单张卡券的唯一标准，必填
+     * @param code 卡券Code码，一张卡券的唯一标识，必填
      * @param cardId 卡券ID代表一类卡券，null表示不填此参数。自定义code卡券必填
      * @return
      */
@@ -361,12 +361,43 @@ public class WxApi2Impl extends AbstractWxApi2 {
      * 微信卡券：查询Code
      *
      * @author JinYi
-     * @param code 单张卡券的唯一标准，必填
+     * @param code 卡券Code码，一张卡券的唯一标识，必填
      * @return
      */
     @Override
     public WxResp card_code_get(String code) {
     	return card_code_get(code, null, null);
+    }
+
+    /**
+     * 微信卡券：核销卡券
+     *
+     * @author JinYi
+     * @param code 需核销的Code码，必填
+     * @param cardId 卡券ID代表一类卡券，null表示不填此参数。创建卡券时use_custom_code填写true时必填。非自定义Code不必填写
+     * @return
+     */
+    @Override
+    public WxResp card_code_consume(String code, String cardId) {
+    	NutMap body = NutMap.NEW().addv("code", code);
+    	if (cardId != null) {
+    		body.addv("card_id", cardId);
+    	}
+
+    	// 由于核销卡券API中没有“/cgi-bin”，所以uri不能只写“/card/code/consume”
+    	return postJson("https://api.weixin.qq.com/card/code/consume", body);
+    }
+
+    /**
+     * 微信卡券：核销卡券
+     *
+     * @author JinYi
+     * @param code 需核销的Code码，必填
+     * @return
+     */
+    @Override
+    public WxResp card_code_consume(String code) {
+    	return card_code_consume(code, null);
     }
 
     // 自定义菜单

--- a/src/main/java/org/nutz/weixin/spi/WxCardApi.java
+++ b/src/main/java/org/nutz/weixin/spi/WxCardApi.java
@@ -10,7 +10,7 @@ import org.nutz.lang.util.NutMap;
 public interface WxCardApi {
 
     /**
-     * 创建卡券
+     * 微信卡券：创建卡券
      *
      * @author JinYi
      * @param card
@@ -19,7 +19,7 @@ public interface WxCardApi {
     WxResp card_create(NutMap card);
 
     /**
-     * 投放卡券，创建二维码
+     * 微信卡券：投放卡券，创建二维码
      *
      * @author JinYi
      * @param body
@@ -27,4 +27,33 @@ public interface WxCardApi {
      */
     WxResp card_qrcode_create(NutMap body);
 
+    /**
+     * 微信卡券：查询Code
+     *
+     * @author JinYi
+     * @param code 单张卡券的唯一标准，必填
+     * @param cardId 卡券ID代表一类卡券，null表示不填此参数。自定义code卡券必填
+     * @param checkConsume 是否校验code核销状态，填入true和false时的code异常状态返回数据不同，null表示不填此参数
+     * @return
+     */
+    WxResp card_code_get(String code, String cardId, Boolean checkConsume);
+
+    /**
+     * 微信卡券：查询Code
+     *
+     * @author JinYi
+     * @param code 单张卡券的唯一标准，必填
+     * @param cardId 卡券ID代表一类卡券，null表示不填此参数。自定义code卡券必填
+     * @return
+     */
+    WxResp card_code_get(String code, String cardId);
+
+    /**
+     * 微信卡券：查询Code
+     *
+     * @author JinYi
+     * @param code 单张卡券的唯一标准，必填
+     * @return
+     */
+    WxResp card_code_get(String code);
 }

--- a/src/main/java/org/nutz/weixin/spi/WxCardApi.java
+++ b/src/main/java/org/nutz/weixin/spi/WxCardApi.java
@@ -58,7 +58,9 @@ public interface WxCardApi {
     WxResp card_code_get(String code);
 
     /**
-     * 微信卡券：核销卡券
+     * 微信卡券：核销卡券<br/>
+     * 建议在调用核销卡券接口之前调用查询Code接口<br/>
+     * 以便在核销之前对非法状态的Code（如转赠中、已删除、已核销等）做出处理
      *
      * @author JinYi
      * @param code 需核销的Code码，必填
@@ -68,7 +70,9 @@ public interface WxCardApi {
     WxResp card_code_consume(String code, String cardId);
 
     /**
-     * 微信卡券：核销卡券
+     * 微信卡券：核销卡券<br/>
+     * 建议在调用核销卡券接口之前调用查询Code接口<br/>
+     * 以便在核销之前对非法状态的Code（如转赠中、已删除、已核销等）做出处理
      *
      * @author JinYi
      * @param code 需核销的Code码，必填

--- a/src/main/java/org/nutz/weixin/spi/WxCardApi.java
+++ b/src/main/java/org/nutz/weixin/spi/WxCardApi.java
@@ -31,7 +31,7 @@ public interface WxCardApi {
      * 微信卡券：查询Code
      *
      * @author JinYi
-     * @param code 单张卡券的唯一标准，必填
+     * @param code 卡券Code码，一张卡券的唯一标识，必填
      * @param cardId 卡券ID代表一类卡券，null表示不填此参数。自定义code卡券必填
      * @param checkConsume 是否校验code核销状态，填入true和false时的code异常状态返回数据不同，null表示不填此参数
      * @return
@@ -42,7 +42,7 @@ public interface WxCardApi {
      * 微信卡券：查询Code
      *
      * @author JinYi
-     * @param code 单张卡券的唯一标准，必填
+     * @param code 卡券Code码，一张卡券的唯一标识，必填
      * @param cardId 卡券ID代表一类卡券，null表示不填此参数。自定义code卡券必填
      * @return
      */
@@ -52,8 +52,27 @@ public interface WxCardApi {
      * 微信卡券：查询Code
      *
      * @author JinYi
-     * @param code 单张卡券的唯一标准，必填
+     * @param code 卡券Code码，一张卡券的唯一标识，必填
      * @return
      */
     WxResp card_code_get(String code);
+
+    /**
+     * 微信卡券：核销卡券
+     *
+     * @author JinYi
+     * @param code 需核销的Code码，必填
+     * @param cardId 卡券ID代表一类卡券，null表示不填此参数。创建卡券时use_custom_code填写true时必填。非自定义Code不必填写
+     * @return
+     */
+    WxResp card_code_consume(String code, String cardId);
+
+    /**
+     * 微信卡券：核销卡券
+     *
+     * @author JinYi
+     * @param code 需核销的Code码，必填
+     * @return
+     */
+    WxResp card_code_consume(String code);
 }


### PR DESCRIPTION
增加功能：
1. 微信卡券，查询Code接口
2. 微信卡券，核销卡券接口

建议在调用核销卡券接口之前调用查询Code接口
以便在核销之前对非法状态的Code（如转赠中、已删除、已核销等）做出处理